### PR TITLE
feat: Day 7 Mini To-Do (CRUD + localStorage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,3 +196,16 @@ export default function Day6List() {
   ))}
 </ul>
 ```
+
+# Day 7 — Mini To-Do
+
+A minimal To-Do app with React state and `localStorage` persistence.
+
+## Features
+- Create task, toggle complete, delete
+- Persist across page reloads (lazy init + save on change)
+
+## How to Run
+```bash
+npm install
+npm run dev

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,9 +5,10 @@ import Day3View from "./views/Day3View";
 import Day4View from "./views/Day4View";
 import Day5View from "./views/Day5View";
 import Day6View from "./views/Day6View";
+import Day7View from "./views/Day7View";
 
 function App() {
-	const day = 6;
+	const day = 7;
 
 	const views = {
 		1: <Day1View />,
@@ -16,6 +17,7 @@ function App() {
 		4: <Day4View />,
 		5: <Day5View />,
 		6: <Day6View />,
+		7: <Day7View />,
 	};
 
 	return (

--- a/src/components/day-7-todo/TodoApp.jsx
+++ b/src/components/day-7-todo/TodoApp.jsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "Day_7_Todos";
+
+function uid() {
+  return `${Date.now()}-${Math.random().toString(36).slice(2,8)}`;
+}
+
+function safeParse(value, fallback) {
+  try {
+    const x = JSON.parse(value)
+    return Array.isArray(x) ? x : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export default function TodoApp() {
+  const [todos, setTodos] = useState(() => {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return safeParse(raw, []);
+  });
+  const [text, setText] = useState("");
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(todos))
+  }, [todos]);
+
+  function addTodo(e){
+    e.preventDefault();
+    const value = text.trim();
+    if (!value) return;
+    setTodos((prev) => [
+      {id: uid(), text: value, done: false, createdAt: Date.now() },
+      ...prev,
+    ]);
+    setText("");
+  }
+
+  function toggleTodo(id) {
+    setTodos((prev) => 
+    prev.map((t) => (t.id === id ? {...t, done: !t.done} : t))
+  );
+  }
+
+  function deleteTodo(id) {
+    setTodos((prev) => prev.filter((t) => t.id !== id));
+  }
+
+  return (
+    <div className="mx-auto max-w-lg p-6">
+      <h1 className="text-xl font-bold mb-4">Day 7 - Mini To Do</h1>
+      <form onSubmit={addTodo} className="flex gap-2 mb-4">
+        <input 
+          className="flex-1 border rounded px-4 py-2"
+          placeholder="Add a new task ..."
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          type="text" 
+        />
+        <button type="submit" className="rounded px-4 py-2 bg-black text-white">Add</button>
+      </form>
+
+      {todos.length === 0 ? (
+        <p className="text-sm text-gray-500">No tasks yet. Add one above!</p>
+      ) : (
+        <ul className="space-y-2">
+          {todos.map(t => (
+            <li key={t.id} className="flex items-center justify-between border rounded px-4 py-2">
+              <label className="flex items-center gap-2">
+                <input type="checkbox" checked={t.done} onChange={() => toggleTodo(t.id)} />
+                <span className={t.done ? "line-through text-gray-500" : ""}>{t.text}</span>
+              </label>
+              <button onClick={() => deleteTodo(t.id)} className="text-sm underline">Delete</button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+};

--- a/src/index.css
+++ b/src/index.css
@@ -31,7 +31,7 @@ body {
 }
 
 h1 {
-  font-size: 3.2em;
+  /* font-size: 3.2em; */
   line-height: 1.1;
 }
 

--- a/src/views/Day7View.jsx
+++ b/src/views/Day7View.jsx
@@ -1,0 +1,11 @@
+import TodoApp from "../components/day-7-todo/TodoApp";
+
+export default function Day7View() {
+	return (
+		<main className="container mx-auto max-w-3xl px-4 py-10 space-y-10">
+			<section className="rounded-lg border p-4">
+				<TodoApp />
+			</section>
+		</main>
+	);
+}


### PR DESCRIPTION
## Day 7 — Mini To-Do (CRUD + localStorage)

Minimal To-Do app using React state with persistence.

### Features
- Create task (ignore empty input)
- Toggle complete (line-through styling)
- Delete task
- Persist to `localStorage` (lazy init + save on change)

### Checklist
- [x] CRUD implemented (Create/Toggle/Delete)
- [x] Persistence across reloads
- [x] Basic UI polish
- [x] Day 7 README added

### Notes
- Stable ids for list keys (no index)
- Pure React state, no external manager

### Screenshots
<img width="1366" height="607" alt="day-7-todo" src="https://github.com/user-attachments/assets/4f31ea53-a9d2-41b2-9cce-f7d899499e2b" />

### Related Issue
Closes #16 
